### PR TITLE
Allow all Scala 3 tests to compile and pass

### DIFF
--- a/pipez/src/main/scala-3/pipez/internal/PlatformProductCaseGeneration.scala
+++ b/pipez/src/main/scala-3/pipez/internal/PlatformProductCaseGeneration.scala
@@ -84,7 +84,7 @@ trait PlatformProductCaseGeneration[Pipe[_, _], In, Out] extends ProductCaseGene
 
       ProductOutData
         .CaseClass(
-          params => Ref(TypeRepr.of[Out].termSymbol).asExpr.asExprOf[Out],
+          params => Ref(TypeRepr.of[Out].typeSymbol.companionModule).asExpr.asExprOf[Out],
           List.empty
         )
         .pipe(DerivationResult.pure(_))

--- a/pipez/src/main/scala-3/pipez/internal/PlatformSumCaseGeneration.scala
+++ b/pipez/src/main/scala-3/pipez/internal/PlatformSumCaseGeneration.scala
@@ -25,7 +25,7 @@ trait PlatformSumCaseGeneration[Pipe[_, _], In, Out] extends SumCaseGeneration[P
   private def extractEnumData[A: Type]: DerivationResult[EnumData[A]] =
     def extractSubclasses(sym: Symbol): List[Symbol] =
       if (sym.flags.is(Flags.Sealed)) sym.children.flatMap(extractSubclasses)
-      else if (sym.flags.is(Flags.Module)) List(sym.companionModule)
+      else if (sym.flags.is(Flags.Module)) List(sym.companionModule.moduleClass)
       else List(sym)
 
     DerivationResult.unsafe[EnumData[A]](


### PR DESCRIPTION
Previously when exploring an ADT tree all case objects would be resolved as `object A` symbols which turned out to be term symbols, which did not play well with the implicit resolution. Now they were changed to `module class A$` type symbols. Additionally referencing case objects was corrected, as the previous way would result in "not a term" assertion errors.
