### PR TITLE
Adopt hearth 0.4.1 pre-release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val scala3 = "3.8.4"
 val scalas = List(scala213, scala3)
 val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
-val hearth = "0.4.0"
+val hearth = "0.4.0-27-g71200e3-SNAPSHOT"
 val kindProjector = "0.13.4"
 val munit = "1.3.3"
 


### PR DESCRIPTION
Bumps hearth 0.4.0 -> 0.4.0-27-g71200e3e-SNAPSHOT (0.4.1 pre-release; #317 owner + #320 fixes). mavenCentralSnapshots resolver via sbt-kubuszok. Pin final 0.4.1 on release. CI resolves once hearth's snapshot publish completes.