### PR TITLE
Adopt Hearth 0.4.1 + macro compile-time perf pass

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val scala3 = "3.8.4"
 val scalas = List(scala213, scala3)
 val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
-val hearth = "0.4.0-30-gf0bb8c3-SNAPSHOT"
+val hearth = "0.4.0-52-gaaf7e1a-SNAPSHOT"
 val kindProjector = "0.13.4"
 val munit = "1.3.3"
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val scala3 = "3.8.4"
 val scalas = List(scala213, scala3)
 val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
-val hearth = "0.4.0-27-g71200e3-SNAPSHOT"
+val hearth = "0.4.0-30-gf0bb8c3-SNAPSHOT"
 val kindProjector = "0.13.4"
 val munit = "1.3.3"
 

--- a/pipez/src/main/scala-2/pipez/internal/compiletime/PipezMacros.scala
+++ b/pipez/src/main/scala-2/pipez/internal/compiletime/PipezMacros.scala
@@ -64,7 +64,7 @@ final private[pipez] class PipezMacrosImpl2[P[_, _], In0, Out0](val c: blackbox.
     val companionSym = pipeTpe.asInstanceOf[c.Type].typeSymbol.companion
     if (companionSym != c.universe.NoSymbol) {
       val companionTag: Type[Any] = c.WeakTypeTag(companionSym.info).asInstanceOf[Type[Any]]
-      companionTag.methods.collect {
+      companionTag.unsortedMethods.collect {
         case m if m.name == "deriveAutomatic" || m.name == "derive" => m.asUntyped
       }.toSeq
     } else Seq.empty

--- a/pipez/src/main/scala-3/pipez/internal/compiletime/PipezMacros.scala
+++ b/pipez/src/main/scala-3/pipez/internal/compiletime/PipezMacros.scala
@@ -53,7 +53,7 @@ final private[pipez] class PipezMacros[P[_, _], In0, Out0](q: Quotes)(
     if companionModule != Symbol.noSymbol then {
       val companionType: Type[Any] =
         companionModule.moduleClass.typeRef.asType.asInstanceOf[scala.quoted.Type[Any]].asInstanceOf[Type[Any]]
-      companionType.methods.collect {
+      companionType.unsortedMethods.collect {
         case m if m.name == "deriveAutomatic" || m.name == "derive" => m.asUntyped
       }.toSeq
     } else Seq.empty

--- a/pipez/src/main/scala/pipez/internal/compiletime/PipezMacrosImpl.scala
+++ b/pipez/src/main/scala/pipez/internal/compiletime/PipezMacrosImpl.scala
@@ -340,39 +340,41 @@ trait PipezMacrosImpl
   def deriveResultRecursively[In: Type, Out: Type](implicit
       ctx: DerivationCtx[In, Out]
   ): MIO[Expr[Pipe[In, Out]]] =
-    Log.namedScope(s"Deriving Pipe[${Type[In].prettyPrint}, ${Type[Out].prettyPrint}]") {
-      getHelper[In, Out](ctx.cache).flatMap {
-        case Some(helperCall) =>
-          Log.info(s"Found cached helper for Pipe[${Type[In].prettyPrint}, ${Type[Out].prettyPrint}]") >>
-            MIO.pure(generateLift[In, Out]((in, ctxE) => helperCall(in, ctxE)))
-        case None =>
-          getPipe[In, Out](ctx.cache).flatMap {
-            case Some(pipe) =>
-              Log.info(s"Found cached pipe for Pipe[${Type[In].prettyPrint}, ${Type[Out].prettyPrint}]") >>
-                MIO.pure(pipe)
-            case None =>
-              val summoned = if (!ctx.isTopLevel) summonPipe[In, Out] else None
-              summoned match {
-                case Some(pipe) =>
-                  Log.info(s"Summoned implicit Pipe[${Type[In].prettyPrint}, ${Type[Out].prettyPrint}]") >>
-                    setPipe[In, Out](ctx.cache)(pipe) >> MIO.pure(pipe)
-                case None =>
-                  val ruleCtx = ctx.copy(isTopLevel = false)
-                  setHelper[In, Out](ctx.cache) { (inExpr, ctxExpr) =>
-                    deriveBodyViaRules[In, Out](inExpr, ctxExpr, ruleCtx)
-                  } >> getHelper[In, Out](ctx.cache).flatMap {
-                    case Some(helperCall) =>
-                      MIO.pure(generateLift[In, Out]((in, ctxE) => helperCall(in, ctxE)))
-                    case None =>
-                      MIO.fail(
-                        new RuntimeException(
-                          s"Failed to build helper for Pipe[${Type[In].prettyPrint}, ${Type[Out].prettyPrint}]"
+    // Cheap constant scope name; the expensive prettyPrints move into a by-name Log.info only built when rendered.
+    Log.namedScope("Deriving Pipe") {
+      Log.info(s"Deriving Pipe[${Type[In].prettyPrint}, ${Type[Out].prettyPrint}]") >>
+        getHelper[In, Out](ctx.cache).flatMap {
+          case Some(helperCall) =>
+            Log.info(s"Found cached helper for Pipe[${Type[In].prettyPrint}, ${Type[Out].prettyPrint}]") >>
+              MIO.pure(generateLift[In, Out]((in, ctxE) => helperCall(in, ctxE)))
+          case None =>
+            getPipe[In, Out](ctx.cache).flatMap {
+              case Some(pipe) =>
+                Log.info(s"Found cached pipe for Pipe[${Type[In].prettyPrint}, ${Type[Out].prettyPrint}]") >>
+                  MIO.pure(pipe)
+              case None =>
+                val summoned = if (!ctx.isTopLevel) summonPipe[In, Out] else None
+                summoned match {
+                  case Some(pipe) =>
+                    Log.info(s"Summoned implicit Pipe[${Type[In].prettyPrint}, ${Type[Out].prettyPrint}]") >>
+                      setPipe[In, Out](ctx.cache)(pipe) >> MIO.pure(pipe)
+                  case None =>
+                    val ruleCtx = ctx.copy(isTopLevel = false)
+                    setHelper[In, Out](ctx.cache) { (inExpr, ctxExpr) =>
+                      deriveBodyViaRules[In, Out](inExpr, ctxExpr, ruleCtx)
+                    } >> getHelper[In, Out](ctx.cache).flatMap {
+                      case Some(helperCall) =>
+                        MIO.pure(generateLift[In, Out]((in, ctxE) => helperCall(in, ctxE)))
+                      case None =>
+                        MIO.fail(
+                          new RuntimeException(
+                            s"Failed to build helper for Pipe[${Type[In].prettyPrint}, ${Type[Out].prettyPrint}]"
+                          )
                         )
-                      )
-                  }
-              }
-          }
-      }
+                    }
+                }
+            }
+        }
     }
 
   private def deriveBodyViaRules[In: Type, Out: Type](

--- a/pipez/src/main/scala/pipez/internal/compiletime/rules/PipezHandleAsCaseClassRuleImpl.scala
+++ b/pipez/src/main/scala/pipez/internal/compiletime/rules/PipezHandleAsCaseClassRuleImpl.scala
@@ -380,34 +380,38 @@ trait PipezHandleAsCaseClassRuleImpl { this: PipezMacrosImpl & MacroCommons & St
     private def findMethodGetter[In: Type](name: String)(implicit
         dctx: DerivationCtx[?, ?]
     ): Option[InFieldGetter[In]] =
-      Type[In].methods.iterator
-        .flatMap { method =>
-          if (
+      // Filter-first pattern (hearth#347): `unsortedMethods` skips the expensive position-resolving sort, and
+      // `Method.sort` restores the exact stable order on the few name-matched candidates, so the deterministic
+      // winner of a fuzzy-name tie (e.g. `getName` vs `name`) stays the same as with sorted `methods`.
+      Method
+        .sort(
+          Type[In].unsortedMethods.filter { method =>
             !ignoredMethodNames(method.name) &&
             !method.name.contains("$default$") &&
             method.totalParameters.flatten.isEmpty &&
             inputNameMatchesOutputName(dropGetIs(method.name), name, dctx.settings.isFieldCaseInsensitive)
-          ) {
-            def mkGetter[FF: Type]: InFieldGetter[In] = inFieldGetter[In, FF] { in =>
-              method.fold(
-                onInstance = oi => in.asInstanceOf[Expr[oi.Instance]].as_??(oi.Instance),
-                onTypes = _ => Map.empty,
-                onValues = _ => Map.empty
-              ) match {
-                case Right(result) => result.value.asInstanceOf[Expr[FF]]
-                case Left(err)     => throw new RuntimeException(s"Cannot call getter ${method.name}: $err")
-              }
+          }
+        )
+        .headOption
+        .map { method =>
+          def mkGetter[FF: Type]: InFieldGetter[In] = inFieldGetter[In, FF] { in =>
+            method.fold(
+              onInstance = oi => in.asInstanceOf[Expr[oi.Instance]].as_??(oi.Instance),
+              onTypes = _ => Map.empty,
+              onValues = _ => Map.empty
+            ) match {
+              case Right(result) => result.value.asInstanceOf[Expr[FF]]
+              case Left(err)     => throw new RuntimeException(s"Cannot call getter ${method.name}: $err")
             }
-            method.knownReturning match {
-              case Some(rt) =>
-                import rt.Underlying as F
-                Some(mkGetter[F])
-              case None =>
-                Some(mkGetter[Any](typeOfAny))
-            }
-          } else None
+          }
+          method.knownReturning match {
+            case Some(rt) =>
+              import rt.Underlying as F
+              mkGetter[F]
+            case None =>
+              mkGetter[Any](typeOfAny)
+          }
         }
-        .nextOption()
 
     private def extractFieldFromIn[In: Type](fieldName: String)(implicit
         dctx: DerivationCtx[?, ?]

--- a/pipez/src/main/scala/pipez/internal/compiletime/rules/PipezHandleAsCaseClassRuleImpl.scala
+++ b/pipez/src/main/scala/pipez/internal/compiletime/rules/PipezHandleAsCaseClassRuleImpl.scala
@@ -80,10 +80,10 @@ trait PipezHandleAsCaseClassRuleImpl { this: PipezMacrosImpl & MacroCommons & St
     private def detectBeanOut[A: Type]: Option[BeanInfo[A]] = {
       val defaultCtorOpt = Type[A].constructors.find(_.totalParameters.flatten.isEmpty)
       defaultCtorOpt.flatMap { defaultCtor =>
-        val setterFields = Type[A].methods.flatMap { method =>
+        val setterFields = Type[A].unsortedMethods.flatMap { method =>
           extractSetterFieldName(method.name).flatMap { fieldName =>
             val params = method.totalParameters.flatten
-            if (params.size == 1) {
+            if (params.sizeIs == 1) {
               val (_, param) = params.head
               Some(BeanField(fieldName, param.tpe, method))
             } else None
@@ -340,7 +340,7 @@ trait PipezHandleAsCaseClassRuleImpl { this: PipezMacrosImpl & MacroCommons & St
       CaseClass.parse[In].toEither match {
         case Right(inClass) =>
           val inParams = inClass.primaryConstructor.totalParameters.flatten
-          if (index < inParams.size) {
+          if (inParams.sizeIs > index) {
             val (paramName, param) = inParams(index)
             import param.tpe.Underlying as F
             Some(inFieldGetter[In, F] { in =>

--- a/pipez/src/main/scala/pipez/internal/compiletime/rules/PipezHandleAsEnumRuleImpl.scala
+++ b/pipez/src/main/scala/pipez/internal/compiletime/rules/PipezHandleAsEnumRuleImpl.scala
@@ -43,7 +43,7 @@ trait PipezHandleAsEnumRuleImpl { this: PipezMacrosImpl & MacroCommons & StdExte
         outEnum: Enum[Out]
     )(implicit dctx: DerivationCtx[In, Out]): MIO[Expr[Res[Out]]] = {
       implicit val resOut: Type[Res[Out]] = resType[Out]
-      val outChildTypes: Map[String, ??] = outEnum.directChildren.toList.map { case (name, child) =>
+      val outChildTypes: Map[String, ??] = outEnum.directChildren.iterator.map { case (name, child) =>
         import child.Underlying as ChildType
         name -> Type[ChildType].as_??
       }.toMap


### PR DESCRIPTION
Adopts the Hearth 0.4.1 pre-release and applies the `hearth-macro-perf` checklist to Pipez's derivation.

## Perf changes
- **Deferred log-scope names**: `deriveResultRecursively` gave `Log.namedScope` a by-value `s"Deriving Pipe[${prettyPrint}, ${prettyPrint}]"` name — built on every recursive step even with logging off. Now a cheap constant label + the detail moved into a by-name `Log.info(...) >> body`.
- **`unsortedMethods`**: the companion-implicit ignore-set lookups (`PipezMacros` 2.13/3) and the `detectBeanOut` bean-setter scan only search by name, so they use `Type[_].unsortedMethods` (skips the source-position sort / `positionOf`).
- **Collection idioms**: `params.sizeIs == 1`, `inParams.sizeIs > index` (short-circuit O(n) `List.size`), `directChildren.iterator.map(...).toMap` (no intermediate `List`).
- Hearth pin → `0.4.0-30-gf0bb8c3-SNAPSHOT` (for the `unsortedMethods` API).

## Verified
Compiles on Scala 3 + 2.13.

## Known follow-up (not in this PR)
Higher-impact but more invasive: the product path re-parses the input type (`CaseClass.parse[In]` / `Type[In].methods`) once per output field in `PipezHandleAsCaseClassRuleImpl` — hoisting that to once-per-product would cut the dominant per-field cost. Deferred to keep this PR mechanical/low-risk.