### PR TITLE
Pin hearth to 0.4.0-54 (enum-order determinism fix)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val scala3 = "3.8.4"
 val scalas = List(scala213, scala3)
 val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
-val hearth = "0.4.0-52-gaaf7e1a-SNAPSHOT"
+val hearth = "0.4.0-54-gcad79ee-SNAPSHOT"
 val kindProjector = "0.13.4"
 val munit = "1.3.3"
 


### PR DESCRIPTION
Bumps the hearth pin to `0.4.0-54-gcad79ee-SNAPSHOT`, carrying **hearth#357** — sealed-hierarchy children come back in stable **declaration order** on Scala 3.

hearth's Scala 3 `directChildrenList` sorted children **after** mapping each `case object` to its synthetic module class, whose source position is often absent during macro expansion → the position-first ordering fell through to an alphabetical fallback, flipping between builds. hearth#357 sorts the **original** child symbol (which carries a real position) first. Keeps Pipez's sealed/enum derivation ordering deterministic.

**Verification:** pipez core 39/43 green on Scala 2.13/3 (0 failures) after `clean` + recompile against the new pin.